### PR TITLE
[build] gradle 설정 수정사항 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,7 @@
 .gradle
 build/
 !api/gradle/wrapper/gradle-wrapper.jar
-!**/src/main/**/build/
-!**/src/test/**/build/
 
 ### IntelliJ IDEA ###
 .idea
-*.iws
-*.iml
-*.ipr
 out/
-!**/src/main/**/out/
-!**/src/test/**/out/

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,21 +1,22 @@
 plugins {
-    id 'org.springframework.boot' version '3.3.5'
-    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id "io.freefair.lombok" version "8.10.2"
+}
+
+apply plugin: 'java'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 group = 'org.flab'
 version = '1.0.0'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    annotationProcessor 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -23,12 +24,3 @@ dependencies {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
-
-bootJar {
-    enabled = true
-}
-
-jar {
-    enabled = false
-}
-

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,10 +1,10 @@
 plugins {
+    id 'java'
     id 'org.springframework.boot'
     id 'io.spring.dependency-management'
-    id "io.freefair.lombok" version "8.10.2"
+    id 'io.freefair.lombok'
 }
 
-apply plugin: 'java'
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
     id 'org.springframework.boot' version '3.3.5' apply false
     id 'io.spring.dependency-management' version '1.1.6' apply false
+    id 'io.freefair.lombok' version '8.10.2' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,4 @@
-subprojects {
-    apply plugin: 'java'
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
-    }
+plugins {
+    id 'org.springframework.boot' version '3.3.5' apply false
+    id 'io.spring.dependency-management' version '1.1.6' apply false
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,9 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 rootProject.name = 'ticketo'
-include 'api'
+include ':api'
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
**[.gitignore]** 
 1. 불필요한 내용을 제거했습니다.

**[build.gradle]**
1. 자바 관련  설정을 서브 프로젝트의 `build.gradle` 파일로 이동시켰습니다.
2. 서브 프로젝트에 설정되는 플러그인의 버전을 지정하도록 추가했습니다.  

**[setting.gradle]**
1. `java toolchain` 에 지정된 jdk 를 다운로드 받을 수 있도록 플러그인을 추가했습니다.
2. 서브 프로젝트의 상대경로를 표시하도록 수정했습니다.

**[api/build.gradle]**
1. 루트 프로젝트에서 관리하는 플러그인의 버전을 제거했습니다.
2. `lombok` 을 플러그인으로 추가하도록 수정했습니다.
3. 자바 관련 설정을 루트 프로젝트의 `build.gradle` 에서 가져왔습니다.
4. `org.springframework.boot` 플러그인이 제공하는 기본 설정을 제거했습니다. (`bootJar`, `jar`)