### PR TITLE
[#28] 뮤지컬, 콘서트 관련 엔티티 추가 및 관련 로직 수정

### DIFF
--- a/api/src/main/java/org/flab/api/domain/event/api/EventController.java
+++ b/api/src/main/java/org/flab/api/domain/event/api/EventController.java
@@ -21,8 +21,8 @@ import org.flab.api.domain.event.service.ConcertService;
 import org.flab.api.domain.event.service.EventService;
 import org.flab.api.domain.event.service.MusicalService;
 import org.flab.api.global.common.ListRequestParams;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.InvalidEventTypeException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -108,7 +108,7 @@ public class EventController {
         } else if(event instanceof Concert concert) {
             return new ConcertResponse(concert);
         } else {
-            throw new CustomException(ErrorCode.INVALID_EVENT_TYPE);
+            throw new InvalidEventTypeException(ErrorCode.INVALID_EVENT_TYPE);
         }
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/api/EventController.java
+++ b/api/src/main/java/org/flab/api/domain/event/api/EventController.java
@@ -10,9 +10,9 @@ import org.flab.api.domain.event.domain.seat.DiscountPolicy;
 import org.flab.api.domain.event.domain.seat.Grade;
 import org.flab.api.domain.event.dto.event.request.EventRequestParams;
 import org.flab.api.domain.event.dto.event.request.MembershipRequest;
-import org.flab.api.domain.event.dto.event.response.ConcertResponse;
 import org.flab.api.domain.event.dto.event.response.EventListResponse;
 import org.flab.api.domain.event.dto.event.response.EventResponse;
+import org.flab.api.domain.event.dto.event.response.concert.ConcertResponse;
 import org.flab.api.domain.event.dto.event.response.musical.MusicalResponse;
 import org.flab.api.domain.event.dto.price.DiscountPolicyResponse;
 import org.flab.api.domain.event.dto.price.EventPriceListResponse;
@@ -53,9 +53,9 @@ public class EventController {
         return ResponseEntity.ok(null);
     }
 
-    @GetMapping("/types/{eventType}/{eventId}")
-    public ResponseEntity<EventResponse> getEvent(@PathVariable String eventType, @PathVariable long eventId) {
-        EventResponse response = getEventResponse(eventType, eventId);
+    @GetMapping("/{eventId}")
+    public ResponseEntity<EventResponse> getEvent(@PathVariable long eventId) {
+        EventResponse response = getEventResponse(eventId);
         return ResponseEntity.ok(response);
     }
 
@@ -70,11 +70,11 @@ public class EventController {
         return ResponseEntity.ok().build();
     }
 
-    private EventResponse getEventResponse(String eventType, long eventId) {
-        EventType type = EventType.validateEventType(eventType);
+    private EventResponse getEventResponse(long eventId) {
+        EventType type =  eventService.getTypeById(eventId);
         return switch (type) {
-            case CONCERT -> convertToEventResponse(concertService.getEvent(eventId));
-            case MUSICAL -> convertToEventResponse(musicalService.getEvent(eventId));
+            case CONCERT -> convertToEventResponse(concertService.getConcert(eventId));
+            case MUSICAL -> convertToEventResponse(musicalService.getMusical(eventId));
         };
     }
 

--- a/api/src/main/java/org/flab/api/domain/event/api/ShowController.java
+++ b/api/src/main/java/org/flab/api/domain/event/api/ShowController.java
@@ -2,7 +2,7 @@ package org.flab.api.domain.event.api;
 
 import lombok.RequiredArgsConstructor;
 import org.flab.api.domain.event.domain.Show;
-import org.flab.api.domain.event.domain.musical.Cast;
+import org.flab.api.domain.event.domain.musical.ShowCast;
 import org.flab.api.domain.event.domain.seat.Grade;
 import org.flab.api.domain.event.domain.seat.SeatList;
 import org.flab.api.domain.event.domain.seat.SeatStatus;
@@ -43,14 +43,14 @@ public class ShowController {
         SeatList seatList =  seatService.getSeatListByShowIdAndStatus(showId, SeatStatus.AVAILABLE);
 
         List<Grade> gradeList = show.getEvent().getGradeList();
-        List<Cast> castList = show.getCastList();
+        List<ShowCast> showCastList = show.getShowCastList();
 
         List<RemainSeatResponse> remainSeatResponseList = gradeList.stream()
                 .map(grade ->
                     new RemainSeatResponse(grade, seatList.countSeatByGradeId(grade.getId())
                 )).toList();
 
-        List<CastResponse> castResponseList = castList.stream().map(CastResponse::new).toList();
+        List<CastResponse> castResponseList = showCastList.stream().map(CastResponse::new).toList();
 
         ShowResponse response = new ShowResponse(show, remainSeatResponseList, castResponseList);
         return ResponseEntity.ok(response);

--- a/api/src/main/java/org/flab/api/domain/event/domain/Event.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/Event.java
@@ -18,6 +18,7 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -85,7 +87,7 @@ public class Event {
             @AttributeOverride(name = "startDateTime", column = @Column(name = "pre_reservation_start_datetime"))
             , @AttributeOverride(name = "endDateTime", column = @Column(name = "pre_reservation_end_datetime"))
     })
-    private Period preReservationPeriod;
+    private PreReservationPeriod preReservationPeriod = new PreReservationPeriod();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="category_id")
@@ -118,4 +120,11 @@ public class Event {
     @Column(name = "updated_at")
     @LastModifiedDate
     private ZonedDateTime updatedAt;
+
+    @PostLoad
+    private void initializeEmbeddable() {
+        if (Objects.isNull(preReservationPeriod)) {
+            preReservationPeriod = new PreReservationPeriod();
+        }
+    }
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/EventType.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/EventType.java
@@ -1,7 +1,7 @@
 package org.flab.api.domain.event.domain;
 
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.InvalidEventTypeException;
 
 import java.util.Arrays;
 
@@ -12,6 +12,6 @@ public enum EventType {
         return Arrays.stream(EventType.values())
                 .filter(type -> type.name().equalsIgnoreCase(eventType))
                 .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_EVENT_TYPE));
+                .orElseThrow(() -> new InvalidEventTypeException(ErrorCode.INVALID_EVENT_TYPE));
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/Image.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/Image.java
@@ -3,12 +3,14 @@ package org.flab.api.domain.event.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NullDataException;
+
+import java.util.Objects;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @Embeddable
 public class Image {
@@ -18,4 +20,24 @@ public class Image {
     @Column(name = "poster_img")
     private final String posterImageUrl;
 
+    public Image(String thumbnailImageUrl, String posterImageUrl) {
+        if (thumbnailImageUrl == null || posterImageUrl == null) {
+            throw new NullDataException(ErrorCode.NULL_IMAGE);
+        }
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.posterImageUrl = posterImageUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Image image = (Image) o;
+        return Objects.equals(thumbnailImageUrl, image.thumbnailImageUrl) && Objects.equals(posterImageUrl, image.posterImageUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(thumbnailImageUrl, posterImageUrl);
+    }
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/PreReservationPeriod.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/PreReservationPeriod.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.flab.api.global.exception.ErrorCode;
-import org.flab.api.global.exception.NullDataException;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -14,17 +12,14 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @Embeddable
-public class Period {
+public class PreReservationPeriod {
     @Column(name="start_datetime", nullable = false)
     private final ZonedDateTime startDateTime;
 
     @Column(name = "end_datetime", nullable = false)
     private final ZonedDateTime endDateTime;
 
-    public Period(ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
-        if(startDateTime == null || endDateTime == null) {
-            throw new NullDataException(ErrorCode.NULL_PERIOD);
-        }
+    public PreReservationPeriod(ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
     }
@@ -33,7 +28,7 @@ public class Period {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Period period = (Period) o;
+        PreReservationPeriod period = (PreReservationPeriod) o;
         return Objects.equals(startDateTime, period.startDateTime) && Objects.equals(endDateTime, period.endDateTime);
     }
 

--- a/api/src/main/java/org/flab/api/domain/event/domain/Show.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/Show.java
@@ -15,7 +15,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.musical.Cast;
+import org.flab.api.domain.event.domain.concert.ShowArtist;
+import org.flab.api.domain.event.domain.musical.ShowCast;
 import org.flab.api.domain.event.domain.seat.Seat;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -46,7 +47,10 @@ public class Show {
     private List<Seat> seatList;
 
     @OneToMany(mappedBy = "show", fetch = FetchType.LAZY)
-    private List<Cast> castList;
+    private List<ShowCast> showCastList;
+
+    @OneToMany(mappedBy = "show", fetch = FetchType.LAZY)
+    private List<ShowArtist> showArtistList;
 
     @Embedded
     @AttributeOverrides({

--- a/api/src/main/java/org/flab/api/domain/event/domain/concert/Artist.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/concert/Artist.java
@@ -1,47 +1,40 @@
-package org.flab.api.domain.event.domain.musical;
+package org.flab.api.domain.event.domain.concert;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.Show;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Entity
-@Table(name = "show_cast")
+@Table(name = "artist")
 @EntityListeners(AuditingEntityListener.class)
-public class Cast {
+public class Artist {
 
     @Id
-    @Column(name="id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @Column(name = "name")
     private String name;
 
-    @Column(name = "image")
+    @Column(name="image")
     private String image;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "show_id")
-    private Show show;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "character_id")
-    private Character character;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/api/src/main/java/org/flab/api/domain/event/domain/concert/Concert.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/concert/Concert.java
@@ -2,12 +2,22 @@ package org.flab.api.domain.event.domain.concert;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.flab.api.domain.event.domain.Event;
+import org.hibernate.annotations.BatchSize;
 
+import java.util.List;
+
+@Getter
 @NoArgsConstructor
 @Entity
 @DiscriminatorValue("CONCERT")
 public class Concert extends Event {
 
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY)
+    private List<EventArtist> artistList;
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/concert/EventArtist.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/concert/EventArtist.java
@@ -1,4 +1,4 @@
-package org.flab.api.domain.event.domain.musical;
+package org.flab.api.domain.event.domain.concert;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,37 +9,32 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import org.flab.api.domain.event.domain.Event;
-import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 @Getter
 @Entity
+@Table(name = "event_artist")
 @EntityListeners(AuditingEntityListener.class)
-public class Character {
-
+public class EventArtist {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
-    private String name;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @BatchSize(size = 100)
-    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY)
-    private List<ShowCast> showCastList;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
@@ -48,5 +43,4 @@ public class Character {
     @Column(name = "updated_at")
     @LastModifiedDate
     private ZonedDateTime updatedAt;
-
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/concert/ShowArtist.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/concert/ShowArtist.java
@@ -1,4 +1,4 @@
-package org.flab.api.domain.event.domain.musical;
+package org.flab.api.domain.event.domain.concert;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,37 +9,33 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.Event;
-import org.hibernate.annotations.BatchSize;
+import org.flab.api.domain.event.domain.Show;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 @Getter
 @Entity
+@Table(name = "show_artist")
 @EntityListeners(AuditingEntityListener.class)
-public class Character {
+public class ShowArtist {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "show_id")
+    private Show show;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
-
-    @BatchSize(size = 100)
-    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY)
-    private List<ShowCast> showCastList;
+    @JoinColumn(name = "event_artist_id")
+    private EventArtist artist;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/api/src/main/java/org/flab/api/domain/event/domain/musical/Actor.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/musical/Actor.java
@@ -3,43 +3,33 @@ package org.flab.api.domain.event.domain.musical;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.Event;
-import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 @Getter
 @Entity
+@Table(name = "actor")
 @EntityListeners(AuditingEntityListener.class)
-public class Character {
+public class Actor {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
-
-    @BatchSize(size = 100)
-    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY)
-    private List<ShowCast> showCastList;
+    @Column(name = "image")
+    private String image;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate
@@ -48,5 +38,4 @@ public class Character {
     @Column(name = "updated_at")
     @LastModifiedDate
     private ZonedDateTime updatedAt;
-
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/musical/ShowCast.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/musical/ShowCast.java
@@ -9,37 +9,37 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.Event;
-import org.hibernate.annotations.BatchSize;
+import org.flab.api.domain.event.domain.Show;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 @Getter
 @Entity
+@Table(name = "show_cast")
 @EntityListeners(AuditingEntityListener.class)
-public class Character {
+public class ShowCast {
 
     @Id
+    @Column(name="id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="actor_id")
+    private Actor actor;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id")
-    private Event event;
+    @JoinColumn(name = "show_id")
+    private Show show;
 
-    @BatchSize(size = 100)
-    @OneToMany(mappedBy = "character", fetch = FetchType.LAZY)
-    private List<ShowCast> showCastList;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id")
+    private Character character;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreatedDate

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/EventResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/EventResponse.java
@@ -1,23 +1,13 @@
 package org.flab.api.domain.event.dto.event.response;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.flab.api.domain.event.domain.EventType;
-import org.flab.api.domain.event.dto.event.response.musical.MusicalResponse;
 
 import java.time.ZonedDateTime;
 
-@JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME
-)
-@JsonSubTypes({
-        @JsonSubTypes.Type(value = ConcertResponse.class, name = "concert"),
-        @JsonSubTypes.Type(value = MusicalResponse.class, name = "musical")
-})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/concert/ArtistResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/concert/ArtistResponse.java
@@ -1,0 +1,26 @@
+package org.flab.api.domain.event.dto.event.response.concert;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.flab.api.domain.event.domain.concert.Artist;
+import org.flab.api.domain.event.domain.concert.EventArtist;
+
+@Getter
+@AllArgsConstructor
+public class ArtistResponse {
+    private long artistId;
+    private String artistName;
+    private String artistImage;
+
+    public ArtistResponse(EventArtist artist) {
+        this.artistId = artist.getArtist().getId();
+        this.artistName = artist.getArtist().getName();
+        this.artistImage = artist.getArtist().getImage();
+    }
+
+    public ArtistResponse(Artist artist) {
+        this.artistId = artist.getId();
+        this.artistName = artist.getName();
+        this.artistImage = artist.getImage();
+    }
+}

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/concert/ConcertResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/concert/ConcertResponse.java
@@ -1,12 +1,24 @@
-package org.flab.api.domain.event.dto.event.response;
+package org.flab.api.domain.event.dto.event.response.concert;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.flab.api.domain.event.domain.concert.Concert;
+import org.flab.api.domain.event.dto.event.response.EventCategoryResponse;
+import org.flab.api.domain.event.dto.event.response.EventImageResponse;
+import org.flab.api.domain.event.dto.event.response.EventResponse;
+import org.flab.api.domain.event.dto.event.response.PlaceResponse;
+import org.flab.api.domain.event.dto.event.response.RegionResponse;
 
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 public class ConcertResponse extends EventResponse {
+
+    private List<ArtistResponse> artists;
 
     public ConcertResponse(Concert concert) {
         super(concert.getId(), concert.getName(), concert.getType(), concert.getEventPeriod().getStartDateTime(), concert.getEventPeriod().getEndDateTime(),
@@ -15,5 +27,9 @@ public class ConcertResponse extends EventResponse {
                 new EventCategoryResponse(concert.getCategory()), new PlaceResponse(concert.getPlace()),
                 new RegionResponse(concert.getRegion()), new EventImageResponse(concert.getImage())
         );
+
+        this.artists = concert.getArtistList().stream()
+                .map(ArtistResponse::new)
+                .toList();
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/ActorResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/ActorResponse.java
@@ -1,0 +1,20 @@
+package org.flab.api.domain.event.dto.event.response.musical;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.flab.api.domain.event.domain.musical.Actor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ActorResponse {
+    private long actorId;
+    private String actorName;
+    private String actorImage;
+
+    public ActorResponse(Actor actor) {
+        this.actorId = actor.getId();
+        this.actorName = actor.getName();
+        this.actorImage = actor.getImage();
+    }
+}

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/CastResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/CastResponse.java
@@ -2,18 +2,16 @@ package org.flab.api.domain.event.dto.event.response.musical;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.flab.api.domain.event.domain.musical.Cast;
+import org.flab.api.domain.event.domain.musical.ShowCast;
 
 @AllArgsConstructor
 @Getter
 public class CastResponse {
     private Long castId;
-    private String castName;
-    private String castImage;
+    private ActorResponse actor;
 
-    public CastResponse(Cast cast) {
-        this.castId = cast.getId();
-        this.castName = cast.getName();
-        this.castImage = cast.getImage();
+    public CastResponse(ShowCast showCast) {
+        this.castId = showCast.getId();
+        this.actor = new ActorResponse(showCast.getActor());
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/CharacterResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/response/musical/CharacterResponse.java
@@ -1,5 +1,6 @@
 package org.flab.api.domain.event.dto.event.response.musical;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,7 +8,7 @@ import org.flab.api.domain.event.domain.musical.Character;
 
 import java.util.List;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 public class CharacterResponse {
@@ -18,7 +19,7 @@ public class CharacterResponse {
     public CharacterResponse(Character character) {
        this.characterId = character.getId();
        this.characterName = character.getName();
-       this.casts = character.getCastList().stream()
+       this.casts = character.getShowCastList().stream()
                             .map(CastResponse::new)
                             .toList();
     }

--- a/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryCustom.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryCustom.java
@@ -1,5 +1,11 @@
 package org.flab.api.domain.event.repository;
 
-public interface EventRepositoryCustom {
+import org.flab.api.domain.event.domain.Event;
+import org.flab.api.domain.event.domain.EventType;
 
+import java.util.Optional;
+
+public interface EventRepositoryCustom {
+    EventType findEventTypeById(long eventId);
+    Optional<Event> findEventWithRelationEntity(long eventId);
 }

--- a/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryCustom.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryCustom.java
@@ -6,6 +6,6 @@ import org.flab.api.domain.event.domain.EventType;
 import java.util.Optional;
 
 public interface EventRepositoryCustom {
-    EventType findEventTypeById(long eventId);
+    Optional<EventType> findEventTypeById(long eventId);
     Optional<Event> findEventWithRelationEntity(long eventId);
 }

--- a/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryImpl.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryImpl.java
@@ -16,12 +16,13 @@ public class EventRepositoryImpl implements EventRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public EventType findEventTypeById(long eventId) {
-        return queryFactory
-                .select(event.type)
-                .from(event)
-                .where(event.id.eq(eventId))
-                .fetchOne();
+    public Optional<EventType> findEventTypeById(long eventId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(event.type)
+                        .from(event)
+                        .where(event.id.eq(eventId))
+                        .fetchOne());
     }
 
     public Optional<Event> findEventWithRelationEntity(long eventId) {

--- a/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryImpl.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/EventRepositoryImpl.java
@@ -2,11 +2,39 @@ package org.flab.api.domain.event.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.flab.api.domain.event.domain.Event;
+import org.flab.api.domain.event.domain.EventType;
+
+import java.util.Optional;
+
+import static org.flab.api.domain.category.domain.QCategory.category;
+import static org.flab.api.domain.event.domain.QEvent.event;
 
 @RequiredArgsConstructor
 public class EventRepositoryImpl implements EventRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    @Override
+    public EventType findEventTypeById(long eventId) {
+        return queryFactory
+                .select(event.type)
+                .from(event)
+                .where(event.id.eq(eventId))
+                .fetchOne();
+    }
 
+    public Optional<Event> findEventWithRelationEntity(long eventId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(event).distinct()
+                        .from(event)
+                        .leftJoin(event.category, category).fetchJoin()
+                        .leftJoin(category.parent).fetchJoin()
+                        .leftJoin(event.place).fetchJoin()
+                        .leftJoin(event.region).fetchJoin()
+                        .where(event.id.eq(eventId))
+                        .fetchOne()
+        );
+    }
 }

--- a/api/src/main/java/org/flab/api/domain/event/repository/concert/ConcertRepositoryImpl.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/concert/ConcertRepositoryImpl.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import static org.flab.api.domain.category.domain.QCategory.category;
 import static org.flab.api.domain.event.domain.concert.QConcert.concert;
+import static org.flab.api.domain.event.domain.concert.QEventArtist.eventArtist;
 
 @RequiredArgsConstructor
 public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
@@ -23,6 +24,8 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
                         .leftJoin(category.parent).fetchJoin()
                         .leftJoin(concert.place).fetchJoin()
                         .leftJoin(concert.region).fetchJoin()
+                        .leftJoin(concert.artistList, eventArtist).fetchJoin()
+                        .leftJoin(eventArtist.artist).fetchJoin()
                         .where(concert.id.eq(eventId))
                         .fetchOne()
         );

--- a/api/src/main/java/org/flab/api/domain/event/service/ConcertService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/ConcertService.java
@@ -17,7 +17,7 @@ public class ConcertService {
 
     private final ConcertRepository concertRepository;
 
-    public Concert getEvent(long eventId) {
+    public Concert getConcert(long eventId) {
         Optional<Concert> concert = concertRepository.findConcertWithRelationEntity(eventId);
         return concert.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
     }

--- a/api/src/main/java/org/flab/api/domain/event/service/ConcertService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/ConcertService.java
@@ -3,8 +3,8 @@ package org.flab.api.domain.event.service;
 import lombok.RequiredArgsConstructor;
 import org.flab.api.domain.event.domain.concert.Concert;
 import org.flab.api.domain.event.repository.concert.ConcertRepository;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +19,6 @@ public class ConcertService {
 
     public Concert getConcert(long eventId) {
         Optional<Concert> concert = concertRepository.findConcertWithRelationEntity(eventId);
-        return concert.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        return concert.orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/service/EventService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/EventService.java
@@ -2,6 +2,7 @@ package org.flab.api.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
 import org.flab.api.domain.event.domain.Event;
+import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.repository.EventRepository;
 import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
@@ -17,8 +18,14 @@ public class EventService {
 
     private final EventRepository eventRepository;
 
+    public EventType getTypeById(long eventId) {
+        EventType type = eventRepository.findEventTypeById(eventId);
+        EventType.validateEventType(type.name());
+        return type;
+    }
+
     public Event getEvent(long eventId) {
-        Optional<Event> event = eventRepository.findById(eventId);
+        Optional<Event> event = eventRepository.findEventWithRelationEntity(eventId);
         return event.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/service/EventService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/EventService.java
@@ -20,8 +20,7 @@ public class EventService {
 
     public EventType getTypeById(long eventId) {
         EventType type = eventRepository.findEventTypeById(eventId).orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
-        EventType.validateEventType(type.name());
-        return type;
+        return  EventType.validateEventType(type.name());
     }
 
     public Event getEvent(long eventId) {

--- a/api/src/main/java/org/flab/api/domain/event/service/EventService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/EventService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.flab.api.domain.event.domain.Event;
 import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.repository.EventRepository;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,13 +19,13 @@ public class EventService {
     private final EventRepository eventRepository;
 
     public EventType getTypeById(long eventId) {
-        EventType type = eventRepository.findEventTypeById(eventId);
+        EventType type = eventRepository.findEventTypeById(eventId).orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
         EventType.validateEventType(type.name());
         return type;
     }
 
     public Event getEvent(long eventId) {
         Optional<Event> event = eventRepository.findEventWithRelationEntity(eventId);
-        return event.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        return event.orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/service/MusicalService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/MusicalService.java
@@ -3,8 +3,8 @@ package org.flab.api.domain.event.service;
 import lombok.RequiredArgsConstructor;
 import org.flab.api.domain.event.domain.musical.Musical;
 import org.flab.api.domain.event.repository.musical.MusicalRepository;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +19,6 @@ public class MusicalService {
 
     public Musical getMusical(long eventId) {
        Optional<Musical> musical = musicalRepository.findMusicalWithRelationEntity(eventId);
-       return musical.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+       return musical.orElseThrow(() -> new NotFoundException(ErrorCode.EVENT_NOT_FOUND));
     }
 }

--- a/api/src/main/java/org/flab/api/domain/event/service/MusicalService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/MusicalService.java
@@ -17,7 +17,7 @@ public class MusicalService {
 
     private final MusicalRepository musicalRepository;
 
-    public Musical getEvent(long eventId) {
+    public Musical getMusical(long eventId) {
        Optional<Musical> musical = musicalRepository.findMusicalWithRelationEntity(eventId);
        return musical.orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
     }

--- a/api/src/main/java/org/flab/api/domain/event/service/ShowService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/ShowService.java
@@ -5,7 +5,7 @@ import org.flab.api.domain.event.domain.Show;
 import org.flab.api.domain.event.repository.show.ShowRepository;
 import org.flab.api.global.exception.ErrorCode;
 import org.flab.api.global.exception.NotFoundException;
-import org.flab.api.global.exception.ValidateException;
+import org.flab.api.global.exception.InvalidShowException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +21,7 @@ public class ShowService {
     public List<Show> getShowListByEventId(long eventId) {
         List<Show> showList = showRepository.findAllByEventId(eventId);
         if(showList.isEmpty()) {
-            throw new ValidateException(ErrorCode.EVENT_HAS_NO_SHOW);
+            throw new InvalidShowException(ErrorCode.EVENT_HAS_NO_SHOW);
         }
         return showList;
     }
@@ -29,7 +29,7 @@ public class ShowService {
     public Show getShowByIdAndEventId(long showId, long eventId) {
         Show show = showRepository.findById(showId).orElseThrow(() -> new NotFoundException(ErrorCode.SHOW_NOT_FOUND));
         if(show.getEvent().getId() != eventId) {
-            throw new ValidateException(ErrorCode.INVALID_EVENT_SHOW);
+            throw new InvalidShowException(ErrorCode.INVALID_EVENT_SHOW);
         }
         return show;
     }

--- a/api/src/main/java/org/flab/api/global/exception/ErrorCode.java
+++ b/api/src/main/java/org/flab/api/global/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     , INVALID_EVENT_TYPE("EVENT-0002", "유효하지 않은 이벤트 타입입니다.")
     , EVENT_HAS_NO_SHOW("EVENT-0003", "이벤트의 회차가 존재하지 않습니다.")
     , INVALID_EVENT_SHOW("EVENT-0004", "이벤트와 회차 정보가 일치하지 않습니다.")
+    , NULL_PERIOD("EVENT-0005", "시작일시 또는 종료일시가 null 입니다.")
+    , NULL_IMAGE("EVENT-0006", "공연의 이미지 데이터가 null 입니다. ")
 
     // show
     , SHOW_NOT_FOUND("SHOW-0001", "존재하지 않는 회차입니다.")

--- a/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
@@ -23,6 +23,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @ExceptionHandler(InvalidShowException.class)
+    protected ResponseEntity<ErrorResponse> handleValidateException(InvalidShowException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = new ErrorResponse(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     @ExceptionHandler(NotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         ErrorCode errorCode = e.getErrorCode();
@@ -30,8 +37,8 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @ExceptionHandler(ValidateException.class)
-    protected ResponseEntity<ErrorResponse> handleValidateException(ValidateException e) {
+    @ExceptionHandler(NullDataException.class)
+    protected ResponseEntity<ErrorResponse> handleValidateException(NullDataException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = new ErrorResponse(errorCode);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
@@ -23,22 +23,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @ExceptionHandler(InvalidShowException.class)
+    @ExceptionHandler({InvalidShowException.class, InvalidEventTypeException.class})
     protected ResponseEntity<ErrorResponse> handleValidateException(InvalidShowException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = new ErrorResponse(errorCode);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @ExceptionHandler(NotFoundException.class)
+    @ExceptionHandler({NotFoundException.class, NullDataException.class})
     protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
-        ErrorCode errorCode = e.getErrorCode();
-        ErrorResponse response = new ErrorResponse(errorCode);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @ExceptionHandler(NullDataException.class)
-    protected ResponseEntity<ErrorResponse> handleValidateException(NullDataException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = new ErrorResponse(errorCode);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/org/flab/api/global/exception/GlobalExceptionHandler.java
@@ -16,13 +16,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
-        ErrorCode errorCode = e.getErrorCode();
-        ErrorResponse response = new ErrorResponse(errorCode);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
     @ExceptionHandler({InvalidShowException.class, InvalidEventTypeException.class})
     protected ResponseEntity<ErrorResponse> handleValidateException(InvalidShowException e) {
         ErrorCode errorCode = e.getErrorCode();

--- a/api/src/main/java/org/flab/api/global/exception/InvalidEventTypeException.java
+++ b/api/src/main/java/org/flab/api/global/exception/InvalidEventTypeException.java
@@ -1,0 +1,13 @@
+package org.flab.api.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidEventTypeException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public InvalidEventTypeException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/api/src/main/java/org/flab/api/global/exception/InvalidShowException.java
+++ b/api/src/main/java/org/flab/api/global/exception/InvalidShowException.java
@@ -3,11 +3,11 @@ package org.flab.api.global.exception;
 import lombok.Getter;
 
 @Getter
-public class ValidateException extends RuntimeException {
+public class InvalidShowException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public ValidateException(ErrorCode errorCode) {
+    public InvalidShowException(ErrorCode errorCode) {
         this.errorCode = errorCode;
     }
 }

--- a/api/src/main/java/org/flab/api/global/exception/NullDataException.java
+++ b/api/src/main/java/org/flab/api/global/exception/NullDataException.java
@@ -1,0 +1,14 @@
+package org.flab.api.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NullDataException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public NullDataException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+}

--- a/api/src/main/resources/database/data.sql
+++ b/api/src/main/resources/database/data.sql
@@ -21,20 +21,21 @@ VALUES
 INSERT INTO place (id, name, created_at, updated_at)
 VALUES
 (1,'고척 스카이 돔', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (2,'올림픽공원 올림픽 홀', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2,'올림픽공원 올림픽 홀', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 INSERT INTO region (id, name, created_at, updated_at)
 VALUES
 (1,'서울', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (2,'인천', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2,'인천', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 
 INSERT INTO event (id, type, name, running_time, intermission_time, category_id, description, event_start_datetime, event_end_datetime, reservation_start_datetime, reservation_end_datetime, has_pre_reservation, pre_reservation_start_datetime, pre_reservation_end_datetime,  place_id, region_id, poster_img, thumbnail_img, created_at, updated_at)
 VALUES
 (1, 'CONCERT','콜드플레이 내한공연', 180, 0, 9, '콜드플레이 내한공연입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12',true,  '2024-11-14 11:33:12', '2024-11-14 11:33:12', 1, 1, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013437_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/24013437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-, (2, 'MUSICAL', '킹키부츠 - 서울', 150, 20,15,  '킹키부츠입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12', false, '2024-11-14 11:33:12', '2024-11-14 11:33:12',  2, 2, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013443_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/240343437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2, 'MUSICAL', '킹키부츠 - 서울', 150, 20,15,  '킹키부츠입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12', false, null, null,  2, 2, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013443_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/240343437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (3, 'CONCERT','K-POP 콘서트', 180, 0, 9, 'K-POP 콘서트입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12',false,  null, null, 1, 1, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013437_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/24013437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 
@@ -51,14 +52,45 @@ VALUES (1, 1, '2024-12-12 18:00:00', '2024-11-12 18:00:00', '2024-12-12 18:00:00
 , (4, 2, '2024-12-13 18:00:00', '2024-11-12 18:00:00', '2024-12-13 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
 , (5, 2, '2024-12-14 18:00:00', '2024-11-12 18:00:00', '2024-12-14 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
 , (6, 2, '2024-12-15 18:00:00', '2024-11-12 18:00:00', '2024-12-15 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
+, (7, 3, '2024-12-15 18:00:00', '2024-11-12 18:00:00', '2024-12-15 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
 ;
 
-INSERT INTO show_cast (id, show_id, character_id, name, image, created_at, updated_at)
-VALUES ( 1, 3,  1, '강홍석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (2, 4, 1,  '서경석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (3, 5, 1,  '최재림', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (4, 3, 3, '김수하', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (5, 4, 3, '김환희', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+INSERT INTO actor(id, name, image, created_at, updated_at)
+VALUES ( 1, '강홍석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2, '서경석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (3, '최재림', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (4, '김수하', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (5, '김환희', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO artist(id, name, image, created_at, updated_at)
+VALUES (1, '콜드플레이', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2, '아이유', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (3, '방탄소년단', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (4, '악동뮤지션', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO event_artist(id, event_id, artist_id,  created_at, updated_at)
+VALUES (1, 1, 1,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 3, 2, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 3, 3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, 3, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO show_artist(id, show_id, event_artist_id, created_at, updated_at)
+VALUES (1, 1, 1,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (2, 2, 1, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (3, 7, 2, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (4, 7, 3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+, (5, 7, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO show_cast (id, show_id, character_id, actor_id, created_at, updated_at)
+VALUES ( 1, 3,  1, 1, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 4, 1,  2,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 5, 1,  3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, 3, 3, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (5, 4, 3, 5, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 INSERT INTO grade (id, name, price, event_id, created_at, updated_at)

--- a/api/src/test/java/org/flab/api/controller/EventControllerTest.java
+++ b/api/src/test/java/org/flab/api/controller/EventControllerTest.java
@@ -1,11 +1,9 @@
 package org.flab.api.controller;
 
 import org.flab.api.BaseIntegrationTest;
-import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.dto.event.request.EventRequestParams;
 import org.flab.api.domain.event.dto.event.request.MembershipRequest;
-import org.flab.api.domain.event.dto.event.response.ConcertResponse;
-import org.flab.api.domain.event.dto.event.response.EventResponse;
+import org.flab.api.domain.event.dto.event.response.concert.ConcertResponse;
 import org.flab.api.domain.event.dto.event.response.musical.MusicalResponse;
 import org.flab.api.domain.event.dto.price.EventPriceListResponse;
 import org.flab.api.global.common.ListRequestParams;
@@ -40,8 +38,8 @@ public class EventControllerTest extends BaseIntegrationTest {
         long musicalId = 2L;
 
         // when
-        ResponseEntity<EventResponse> response = restTemplate.getForEntity(BASE_URI+ "/types/{eventType}/{musicalId}"
-                , EventResponse.class, EventType.MUSICAL.toString().toLowerCase(), musicalId);
+        ResponseEntity<MusicalResponse> response = restTemplate.getForEntity(BASE_URI+ "/{musicalId}"
+                , MusicalResponse.class, musicalId);
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -56,8 +54,8 @@ public class EventControllerTest extends BaseIntegrationTest {
         long concertId = 1L;
 
         // when
-        ResponseEntity<EventResponse> response = restTemplate.getForEntity(BASE_URI+ "/types/{eventType}/{concertId}"
-                , EventResponse.class, EventType.CONCERT.toString().toLowerCase(), concertId);
+        ResponseEntity<ConcertResponse> response = restTemplate.getForEntity(BASE_URI+ "/{concertId}"
+                , ConcertResponse.class, concertId);
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/api/src/test/java/org/flab/api/controller/ShowControllerTest.java
+++ b/api/src/test/java/org/flab/api/controller/ShowControllerTest.java
@@ -5,7 +5,7 @@ import org.flab.api.domain.event.dto.show.ShowListResponse;
 import org.flab.api.domain.event.dto.show.ShowResponse;
 import org.flab.api.global.exception.ErrorCode;
 import org.flab.api.global.exception.GlobalExceptionHandler;
-import org.flab.api.global.exception.ValidateException;
+import org.flab.api.global.exception.InvalidShowException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -41,7 +41,7 @@ public class ShowControllerTest extends BaseIntegrationTest {
         // when
         try {
             restTemplate.getForEntity(BASE_URI, GlobalExceptionHandler.ErrorResponse.class, eventId);
-        } catch(ValidateException e) {
+        } catch(InvalidShowException e) {
             // then
             assertEquals(e.getErrorCode(), ErrorCode.EVENT_HAS_NO_SHOW);
         }
@@ -73,7 +73,7 @@ public class ShowControllerTest extends BaseIntegrationTest {
         // when
         try {
             restTemplate.getForEntity(BASE_URI + "/{showId}", GlobalExceptionHandler.ErrorResponse.class, eventId, showId);
-        } catch(ValidateException e) {
+        } catch(InvalidShowException e) {
             // then
             assertEquals(e.getErrorCode(), ErrorCode.INVALID_EVENT_SHOW);
         }

--- a/api/src/test/java/org/flab/api/controller/ShowControllerTest.java
+++ b/api/src/test/java/org/flab/api/controller/ShowControllerTest.java
@@ -36,7 +36,7 @@ public class ShowControllerTest extends BaseIntegrationTest {
     @DisplayName("회차 없는 이벤트, 회차 목록 조회 요청")
     public void getShowListResponseWithNoShows() {
         // given
-        long eventId = 3L;
+        long eventId = 404L;
 
         // when
         try {

--- a/api/src/test/java/org/flab/api/domain/SeatListTest.java
+++ b/api/src/test/java/org/flab/api/domain/SeatListTest.java
@@ -4,15 +4,14 @@ import org.flab.api.domain.event.domain.seat.Grade;
 import org.flab.api.domain.event.domain.seat.Seat;
 import org.flab.api.domain.event.domain.seat.SeatList;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -21,24 +20,33 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 public class SeatListTest {
 
-    @ParameterizedTest
-    @MethodSource("provideSeatCountTestData")
+    @Test
     @DisplayName("좌석 등급 별 좌석 수 카운트")
-    public void countSeatByGradeId(long gradeId, long expectedCount) {
+    public void countSeatByGradeId() {
         // given
-        List<Seat> seatEntityList = createSeatListMockByGradeId(gradeId, expectedCount);
+        Map<Long, Long> createSeatMap = new HashMap<>();
+        createSeatMap.put(1L, 1L);
+        createSeatMap.put(2L, 3L);
+        createSeatMap.put(3L, 4L);
+        createSeatMap.put(4L, 0L);
 
-        // when
+        List<Seat> seatEntityList = new ArrayList<>();
+        for(Map.Entry<Long, Long> entry : createSeatMap.entrySet()) {
+            seatEntityList.addAll(createSeatListMockByGradeId(entry.getKey(), entry.getValue()));
+        }
         SeatList target = new SeatList(seatEntityList);
-        long count = target.countSeatByGradeId(gradeId);
 
-        // then
-        assertThat(count).isEqualTo(expectedCount);
+        for(Map.Entry<Long, Long> entry : createSeatMap.entrySet()) {
+            // when
+            long count = target.countSeatByGradeId(entry.getKey());
+            // then
+            assertThat(count).isEqualTo(entry.getValue());
+        }
     }
 
-    private List<Seat> createSeatListMockByGradeId(long gradeId, long expectedCount) {
+    private List<Seat> createSeatListMockByGradeId(long gradeId, long createdCount) {
         List<Seat> seatList = new ArrayList<>();
-        for (int i = 0; i < expectedCount; i++) {
+        for (int i = 0; i < createdCount; i++) {
             Grade gradeMock = mock(Grade.class);
             given(gradeMock.getId()).willReturn(gradeId);
 
@@ -48,14 +56,5 @@ public class SeatListTest {
             seatList.add(seatMock);
         }
         return seatList;
-    }
-
-    private static Stream<Arguments> provideSeatCountTestData() {
-        return Stream.of(
-                Arguments.of(1, 1),
-                Arguments.of(2, 2),
-                Arguments.of(3, 4),
-                Arguments.of(7, 0)
-        );
     }
 }

--- a/api/src/test/java/org/flab/api/domain/SeatListTest.java
+++ b/api/src/test/java/org/flab/api/domain/SeatListTest.java
@@ -10,12 +10,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SeatListTest {
@@ -36,33 +37,17 @@ public class SeatListTest {
     }
 
     private List<Seat> createSeatListMockByGradeId(long gradeId, long expectedCount) {
-        List<Seat> seatList = new java.util.ArrayList<>(createBaseSeatListMock());
-        for(int i=0; i<expectedCount; i++) {
+        List<Seat> seatList = new ArrayList<>();
+        for (int i = 0; i < expectedCount; i++) {
             Grade gradeMock = mock(Grade.class);
-            when(gradeMock.getId()).thenReturn(gradeId);
+            given(gradeMock.getId()).willReturn(gradeId);
+
             Seat seatMock = mock(Seat.class);
-            when(seatMock.getGrade()).thenReturn(gradeMock);
+            given(seatMock.getGrade()).willReturn(gradeMock);
+
             seatList.add(seatMock);
         }
         return seatList;
-    }
-
-    private List<Seat> createBaseSeatListMock() {
-        Grade gradeMock1 = mock(Grade.class);
-        Grade gradeMock2 = mock(Grade.class);
-        Grade gradeMock3 = mock(Grade.class);
-        when(gradeMock1.getId()).thenReturn(4L);
-        when(gradeMock2.getId()).thenReturn(5L);
-        when(gradeMock3.getId()).thenReturn(6L);
-
-        Seat seatMock1 = mock(Seat.class);
-        Seat seatMock2 = mock(Seat.class);
-        Seat seatMock3 = mock(Seat.class);
-        when(seatMock1.getGrade()).thenReturn(gradeMock1);
-        when(seatMock2.getGrade()).thenReturn(gradeMock2);
-        when(seatMock3.getGrade()).thenReturn(gradeMock3);
-
-        return List.of(seatMock1, seatMock2, seatMock3);
     }
 
     private static Stream<Arguments> provideSeatCountTestData() {

--- a/api/src/test/java/org/flab/api/service/ConcertServiceTest.java
+++ b/api/src/test/java/org/flab/api/service/ConcertServiceTest.java
@@ -4,8 +4,8 @@ import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.domain.concert.Concert;
 import org.flab.api.domain.event.repository.concert.ConcertRepository;
 import org.flab.api.domain.event.service.ConcertService;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +44,7 @@ public class ConcertServiceTest {
         given(concertRepository.findConcertWithRelationEntity(concertId)).willReturn(Optional.of(mockConcert));
 
         // when
-        Concert result = target.getEvent(concertId);
+        Concert result = target.getConcert(concertId);
 
         // then
         verify(concertRepository).findConcertWithRelationEntity(concertId);
@@ -59,7 +59,7 @@ public class ConcertServiceTest {
         given(concertRepository.findConcertWithRelationEntity(notFoundId)).willReturn(Optional.empty());
 
         // when
-        CustomException exception = assertThrows(CustomException.class, () -> target.getEvent(notFoundId));
+        NotFoundException exception = assertThrows(NotFoundException.class, () -> target.getConcert(notFoundId));
 
         // then
         verify(concertRepository).findConcertWithRelationEntity(notFoundId);

--- a/api/src/test/java/org/flab/api/service/EventServiceTest.java
+++ b/api/src/test/java/org/flab/api/service/EventServiceTest.java
@@ -1,11 +1,26 @@
 package org.flab.api.service;
 
+import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.repository.EventRepository;
 import org.flab.api.domain.event.service.EventService;
+import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.InvalidEventTypeException;
+import org.flab.api.global.exception.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 
 @ExtendWith(MockitoExtension.class)
 public class EventServiceTest {
@@ -16,4 +31,51 @@ public class EventServiceTest {
     @InjectMocks
     private EventService target;
 
+    @Test
+    @DisplayName("이벤트 타입 조회")
+    public void getEventType() {
+        // given
+        long eventId = 1L;
+        EventType type = EventType.CONCERT;
+        given(eventRepository.findEventTypeById(eventId)).willReturn(Optional.of(type));
+
+        // when
+        EventType eventType = target.getTypeById(eventId);
+
+        // then
+        verify(eventRepository).findEventTypeById(eventId);
+        assertThat(eventType.name()).isEqualTo(EventType.CONCERT.name());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이벤트 타입 조회 시 예외 발생")
+    public void getEventTypeByIdWithInvalidEventType() {
+        // given
+        long eventId = 1L;
+        EventType type = mock(EventType.class);
+        given(type.name()).willReturn("INVALID_TYPE");
+        given(eventRepository.findEventTypeById(eventId)).willReturn(Optional.of(type));
+
+        // when
+        InvalidEventTypeException exception = assertThrows(InvalidEventTypeException.class, () -> target.getTypeById(eventId));
+
+        // then
+        verify(eventRepository).findEventTypeById(eventId);
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_EVENT_TYPE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트의 타입 조회 시 예외 발생")
+    public void getEventTypeByIdWithNoEvent() {
+        // given
+        long eventId = 1L;
+        given(eventRepository.findEventTypeById(eventId)).willReturn(Optional.empty());
+
+        // when
+        NotFoundException exception = assertThrows(NotFoundException.class, () -> target.getTypeById(eventId));
+
+        // then
+        verify(eventRepository).findEventTypeById(eventId);
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.EVENT_NOT_FOUND);
+    }
 }

--- a/api/src/test/java/org/flab/api/service/MusicalServiceTest.java
+++ b/api/src/test/java/org/flab/api/service/MusicalServiceTest.java
@@ -4,8 +4,8 @@ import org.flab.api.domain.event.domain.EventType;
 import org.flab.api.domain.event.domain.musical.Musical;
 import org.flab.api.domain.event.repository.musical.MusicalRepository;
 import org.flab.api.domain.event.service.MusicalService;
-import org.flab.api.global.exception.CustomException;
 import org.flab.api.global.exception.ErrorCode;
+import org.flab.api.global.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +59,7 @@ public class MusicalServiceTest {
         given(musicalRepository.findMusicalWithRelationEntity(notFoundId)).willReturn(Optional.empty());
 
         // when
-        CustomException exception = assertThrows(CustomException.class, () -> target.getMusical(notFoundId));
+        NotFoundException exception = assertThrows(NotFoundException.class, () -> target.getMusical(notFoundId));
 
         // then
         verify(musicalRepository).findMusicalWithRelationEntity(notFoundId);

--- a/api/src/test/java/org/flab/api/service/MusicalServiceTest.java
+++ b/api/src/test/java/org/flab/api/service/MusicalServiceTest.java
@@ -44,7 +44,7 @@ public class MusicalServiceTest {
         given(musicalRepository.findMusicalWithRelationEntity(musicalId)).willReturn(Optional.of(mockMusical));
 
         // when
-        Musical result = target.getEvent(musicalId);
+        Musical result = target.getMusical(musicalId);
 
         // then
         verify(musicalRepository).findMusicalWithRelationEntity(musicalId);
@@ -59,7 +59,7 @@ public class MusicalServiceTest {
         given(musicalRepository.findMusicalWithRelationEntity(notFoundId)).willReturn(Optional.empty());
 
         // when
-        CustomException exception = assertThrows(CustomException.class, () -> target.getEvent(notFoundId));
+        CustomException exception = assertThrows(CustomException.class, () -> target.getMusical(notFoundId));
 
         // then
         verify(musicalRepository).findMusicalWithRelationEntity(notFoundId);

--- a/api/src/test/java/org/flab/api/service/ShowServiceTest.java
+++ b/api/src/test/java/org/flab/api/service/ShowServiceTest.java
@@ -6,7 +6,7 @@ import org.flab.api.domain.event.repository.show.ShowRepository;
 import org.flab.api.domain.event.service.ShowService;
 import org.flab.api.global.exception.ErrorCode;
 import org.flab.api.global.exception.NotFoundException;
-import org.flab.api.global.exception.ValidateException;
+import org.flab.api.global.exception.InvalidShowException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,7 +61,7 @@ public class ShowServiceTest {
         given(showRepository.findAllByEventId(eventId)).willReturn(List.of());
 
         // when
-        ValidateException exception = assertThrows(ValidateException.class, () -> target.getShowListByEventId(eventId));
+        InvalidShowException exception = assertThrows(InvalidShowException.class, () -> target.getShowListByEventId(eventId));
 
         // then
         verify(showRepository).findAllByEventId(eventId);
@@ -117,7 +117,7 @@ public class ShowServiceTest {
         given(showRepository.findById(showId)).willReturn(Optional.of(showMock));
 
         // when
-        ValidateException exception = assertThrows(ValidateException.class, () -> target.getShowByIdAndEventId(showId, wrongEventId));
+        InvalidShowException exception = assertThrows(InvalidShowException.class, () -> target.getShowByIdAndEventId(showId, wrongEventId));
 
         // then
         verify(showRepository).findById(showId);

--- a/api/src/test/resources/database/data.sql
+++ b/api/src/test/resources/database/data.sql
@@ -34,7 +34,8 @@ VALUES
 INSERT INTO event (id, type, name, running_time, intermission_time, category_id, description, event_start_datetime, event_end_datetime, reservation_start_datetime, reservation_end_datetime, has_pre_reservation, pre_reservation_start_datetime, pre_reservation_end_datetime,  place_id, region_id, poster_img, thumbnail_img, created_at, updated_at)
 VALUES
 (1, 'CONCERT','콜드플레이 내한공연', 180, 0, 9, '콜드플레이 내한공연입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12',true,  '2024-11-14 11:33:12', '2024-11-14 11:33:12', 1, 1, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013437_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/24013437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (2, 'MUSICAL', '킹키부츠 - 서울', 150, 20,15,  '킹키부츠입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12', false, '2024-11-14 11:33:12', '2024-11-14 11:33:12',  2, 2, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013443_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/240343437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 'MUSICAL', '킹키부츠 - 서울', 150, 20,15,  '킹키부츠입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12', false, null, null,  2, 2, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013443_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/240343437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 'CONCERT','K-POP 콘서트', 180, 0, 9, 'K-POP 콘서트입니다.','2024-11-12 11:33:12', '2024-11-12 11:33:12', '2024-11-14 11:33:12', '2024-11-14 11:33:12',false,  null, null, 1, 1, '//ticketimage.ticketo.com/Play/image/thumbnail/24/24013437_p.gif', '//ticketimage.ticketo.comrz/image/play/events/poster/24/24013437_p_s.jpg', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 
@@ -51,14 +52,45 @@ VALUES (1, 1, '2024-12-12 18:00:00', '2024-11-12 18:00:00', '2024-12-12 18:00:00
      , (4, 2, '2024-12-13 18:00:00', '2024-11-12 18:00:00', '2024-12-13 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
      , (5, 2, '2024-12-14 18:00:00', '2024-11-12 18:00:00', '2024-12-14 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
      , (6, 2, '2024-12-15 18:00:00', '2024-11-12 18:00:00', '2024-12-15 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
+     , (7, 3, '2024-12-15 18:00:00', '2024-11-12 18:00:00', '2024-12-15 18:00:00', '2024-11-12 11:33:12', '2024-11-12 11:33:12')
 ;
 
-INSERT INTO show_cast (id, show_id, character_id, name, image, created_at, updated_at)
-VALUES ( 1, 3,  1, '강홍석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (2, 4, 1,  '서경석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (3, 5, 1,  '최재림', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (4, 3, 3, '김수하', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
-     , (5, 4, 3, '김환희', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+INSERT INTO actor(id, name, image, created_at, updated_at)
+VALUES ( 1, '강홍석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, '서경석', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, '최재림', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif','2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, '김수하', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (5, '김환희', '//ticketimage.ticketo.com/Play/image/actor/25/2234333443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO artist(id, name, image, created_at, updated_at)
+VALUES (1, '콜드플레이', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, '아이유', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, '방탄소년단', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, '악동뮤지션', '//ticketimage.ticketo.com/Play/image/actor/24/24013443_p.gif', '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO event_artist(id, event_id, artist_id,  created_at, updated_at)
+VALUES (1, 1, 1,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 3, 2, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 3, 3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, 3, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO show_artist(id, show_id, event_artist_id, created_at, updated_at)
+VALUES (1, 1, 1,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 2, 1, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 7, 2, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, 7, 3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (5, 7, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+;
+
+INSERT INTO show_cast (id, show_id, character_id, actor_id, created_at, updated_at)
+VALUES ( 1, 3,  1, 1, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (2, 4, 1,  2,'2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (3, 5, 1,  3, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (4, 3, 3, 4, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
+     , (5, 4, 3, 5, '2024-11-12 11:33:12', '2024-11-14 11:33:12')
 ;
 
 INSERT INTO grade (id, name, price, event_id, created_at, updated_at)


### PR DESCRIPTION
1. 엔티티를 추가했습니다.
actor, artist, show_artist, event_artist
![image](https://github.com/user-attachments/assets/deeb585f-6426-431b-bc0a-4d309329c513)

3. 이벤트 조회 URI 를 수정했습니다.
before : {{local8080}}/api/events/type/{type}/{{eventId}}
after :  {{local8080}}/api/events/{{eventId}}

4. 값 타입 객체를 수정했습니다.
불변객체로 사용할 수 있도록 하고, 선예매가 없는 이벤트인 경우 시작일시, 종료일시에 null 값을 가질 수 있도록 클래스를 분리 했습니다. (`PreReservationPeriod.java`)

5. CustomException 을 제거했습니다.
좀 더 명확한 Exception 으로 표현할 수 있도록 했습니다.
