### PR TITLE
[#34] preReservationPeriod 수정

### DIFF
--- a/api/src/main/java/org/flab/api/domain/event/domain/event/Event.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/event/Event.java
@@ -18,7 +18,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -35,7 +34,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -87,7 +85,7 @@ public class Event {
             @AttributeOverride(name = "startDateTime", column = @Column(name = "pre_reservation_start_datetime"))
             , @AttributeOverride(name = "endDateTime", column = @Column(name = "pre_reservation_end_datetime"))
     })
-    private PreReservationPeriod preReservationPeriod = new PreReservationPeriod();
+    private NullablePeriod nullablePeriod = new NullablePeriod();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="category_id")
@@ -120,11 +118,4 @@ public class Event {
     @Column(name = "updated_at")
     @LastModifiedDate
     private ZonedDateTime updatedAt;
-
-    @PostLoad
-    private void initializeEmbeddable() {
-        if (Objects.isNull(preReservationPeriod)) {
-            preReservationPeriod = new PreReservationPeriod();
-        }
-    }
 }

--- a/api/src/main/java/org/flab/api/domain/event/domain/event/NullablePeriod.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/event/NullablePeriod.java
@@ -12,14 +12,14 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @Embeddable
-public class PreReservationPeriod {
-    @Column(name="start_datetime", nullable = false)
+public class NullablePeriod {
+    @Column(name="start_datetime")
     private final ZonedDateTime startDateTime;
 
-    @Column(name = "end_datetime", nullable = false)
+    @Column(name = "end_datetime")
     private final ZonedDateTime endDateTime;
 
-    public PreReservationPeriod(ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
+    public NullablePeriod(ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
     }
@@ -28,7 +28,7 @@ public class PreReservationPeriod {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PreReservationPeriod period = (PreReservationPeriod) o;
+        NullablePeriod period = (NullablePeriod) o;
         return Objects.equals(startDateTime, period.startDateTime) && Objects.equals(endDateTime, period.endDateTime);
     }
 

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/concert/ConcertResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/concert/ConcertResponse.java
@@ -23,7 +23,7 @@ public class ConcertResponse extends EventResponse {
     public ConcertResponse(Concert concert) {
         super(concert.getId(), concert.getName(), concert.getType(), concert.getEventPeriod().getStartDateTime(), concert.getEventPeriod().getEndDateTime(),
                 concert.getRunningTime(), concert.getDescription(), concert.getReservationPeriod().getStartDateTime(), concert.getReservationPeriod().getEndDateTime(),
-                concert.getHasPreReservation(), concert.getPreReservationPeriod().getStartDateTime(), concert.getPreReservationPeriod().getEndDateTime(),
+                concert.getHasPreReservation(), concert.getNullablePeriod().getStartDateTime(), concert.getNullablePeriod().getEndDateTime(),
                 new EventCategoryResponse(concert.getCategory()), new PlaceResponse(concert.getPlace()),
                 new RegionResponse(concert.getRegion()), new EventImageResponse(concert.getImage())
         );

--- a/api/src/main/java/org/flab/api/domain/event/dto/event/musical/MusicalResponse.java
+++ b/api/src/main/java/org/flab/api/domain/event/dto/event/musical/MusicalResponse.java
@@ -20,12 +20,13 @@ public class MusicalResponse extends EventResponse {
 
     public MusicalResponse(Musical musical) {
         super(musical.getId(), musical.getName(), musical.getType(), musical.getEventPeriod().getStartDateTime(), musical.getEventPeriod().getEndDateTime(),
-        musical.getRunningTime(), musical.getDescription(), musical.getReservationPeriod().getStartDateTime(), musical.getReservationPeriod().getEndDateTime(),
-        musical.getHasPreReservation(), musical.getPreReservationPeriod().getStartDateTime(), musical.getPreReservationPeriod().getEndDateTime(),
+                musical.getRunningTime(), musical.getDescription(), musical.getReservationPeriod().getStartDateTime(), musical.getReservationPeriod().getEndDateTime(),
+                musical.getHasPreReservation(),
+                musical.getHasPreReservation() ? musical.getNullablePeriod().getStartDateTime() : null,
+                musical.getHasPreReservation() ? musical.getNullablePeriod().getEndDateTime() : null,
                 new EventCategoryResponse(musical.getCategory()), new PlaceResponse(musical.getPlace()),
                 new RegionResponse(musical.getRegion()), new EventImageResponse(musical.getImage())
         );
-
         this.interMissionTime= musical.getIntermissionTime();
         this.casts = musical.getCharacterList().stream()
                         .map(CharacterResponse::new)


### PR DESCRIPTION
1. 클래스명 수정
`PreReservationPeriod`  에서 `NullablePeriod` 로 수정하여 용도를 명확하게 나타낸다.

2. 값이 null 인 경우 응답
필드명은 내려주고, 필드의 값을 null 로 응답한다.

3. `@PostLoad` 제거
엔티티 생성 시점에 초기화하지 않고 응답 객체 생성 시점에 선예매 여부를 확인하여 null 값을 넣어준다.