### PR TITLE
[#48] bulk insert 사용해서 좌석 생성하도록 변경, 좌석 캐싱 단계 제거

### DIFF
--- a/api/src/main/java/org/flab/api/domain/event/domain/seat/Seat.java
+++ b/api/src/main/java/org/flab/api/domain/event/domain/seat/Seat.java
@@ -41,6 +41,7 @@ public class Seat {
     private Long colNumber;
 
     @Enumerated(EnumType.STRING)
+    @Column(name ="status")
     private SeatStatus status;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/api/src/main/java/org/flab/api/domain/event/repository/seat/BulkInsertRepository.java
+++ b/api/src/main/java/org/flab/api/domain/event/repository/seat/BulkInsertRepository.java
@@ -1,0 +1,48 @@
+package org.flab.api.domain.event.repository.seat;
+
+import lombok.RequiredArgsConstructor;
+import org.flab.api.domain.event.domain.seat.Seat;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BulkInsertRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<Seat> seatList) {
+
+        String sql = "INSERT INTO SEAT(show_id, zone_id, row_number, col_number, status, created_at, updated_at) " +
+                "values (?, ?, ?, ?, ?, ?, ?)";
+        jdbcTemplate.batchUpdate(sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setLong(1, seatList.get(i).getShow().getId());
+                        ps.setLong(2, seatList.get(i).getZone().getId());
+                        ps.setLong(3, seatList.get(i).getRowNumber());
+                        ps.setLong(4, seatList.get(i).getColNumber());
+                        ps.setString(5, seatList.get(i).getStatus().toString());
+                        ps.setString(6, seatList.get(i).getCreatedAt().toString());
+                        if(seatList.get(i).getUpdatedAt() != null) {
+                            ps.setString(7, seatList.get(i).getUpdatedAt().toString());
+                        } else {
+                            ps.setNull(7, java.sql.Types.TIMESTAMP);
+                        }
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return seatList.size();
+                    }
+                });
+    }
+}

--- a/api/src/main/java/org/flab/api/domain/event/service/seat/SeatCacheService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/seat/SeatCacheService.java
@@ -1,7 +1,6 @@
 package org.flab.api.domain.event.service.seat;
 
 import lombok.RequiredArgsConstructor;
-import org.flab.api.domain.event.domain.seat.Seat;
 import org.flab.api.domain.event.dto.seat.SeatResponse;
 import org.flab.api.domain.event.repository.seat.SeatRepository;
 import org.flab.api.global.cache.CacheConstant;
@@ -25,11 +24,6 @@ public class SeatCacheService {
     @CacheEvict(value = CacheConstant.SHOW, key="T(org.flab.api.global.cache.CacheKeyGenerator).preparedSeatsForShowKeyGenerate(#showId)")
     public void evictPreparedSeatsForShow(Long showId) {
 
-    }
-
-    @Cacheable(value = CacheConstant.SEAT, key = "#seat.id")
-    public SeatResponse cacheSeat(Seat seat) {
-        return new SeatResponse(seat);
     }
 
     @Cacheable(value = CacheConstant.SEAT, key = "#seatId")

--- a/api/src/main/java/org/flab/api/domain/event/service/seat/SeatService.java
+++ b/api/src/main/java/org/flab/api/domain/event/service/seat/SeatService.java
@@ -6,6 +6,7 @@ import org.flab.api.domain.event.domain.seat.Seat;
 import org.flab.api.domain.event.domain.seat.SeatStatus;
 import org.flab.api.domain.event.domain.seat.Zone;
 import org.flab.api.domain.event.domain.show.Show;
+import org.flab.api.domain.event.repository.seat.BulkInsertRepository;
 import org.flab.api.domain.event.repository.seat.SeatRepository;
 import org.flab.api.domain.place.domain.Place;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import java.util.Map;
 public class SeatService {
 
     private final SeatRepository seatRepository;
+    private final BulkInsertRepository bulkInsertRepository;
     private final SeatCacheService seatCacheService;
     private final ZoneService zoneService;
 
@@ -39,9 +41,8 @@ public class SeatService {
 
         seatList = generateSeatListByPlace(show.getEvent().getPlace(), show);
         if(!seatList.isEmpty()) {
-            List<Seat> createdSeatList = seatRepository.saveAll(seatList);
+            bulkInsertRepository.saveAll(seatList);
             seatCacheService.evictPreparedSeatsForShow(show.getId());
-            createdSeatList.forEach(seatCacheService::cacheSeat);
         }
         return seatList;
     }


### PR DESCRIPTION
1. bulk insert 하도록 수정
 jpa 의 `saveAll()` 대신 jdbc template 을 사용해서 bulk insert 하도록 수정했습니다.

2. 좌석 생성 후 좌석 개별 캐싱하는 로직을 제거했습니다. 
개별 좌석 조회 시 캐싱하도록 할 예정입니다.